### PR TITLE
Speed up WebGL rendering

### DIFF
--- a/src/CellGrid/RenderWebGL.elm
+++ b/src/CellGrid/RenderWebGL.elm
@@ -31,11 +31,10 @@ module CellGrid.RenderWebGL exposing
 
 import Array
 import CellGrid exposing (CellGrid(..), matrixIndex)
-import Html exposing (Html)
+import Html
 import Html.Attributes exposing (height, style, width)
-import Json.Decode exposing (Value)
 import Math.Matrix4 as Mat4 exposing (Mat4)
-import Math.Vector3 as Vec3 exposing (Vec3, vec3)
+import Math.Vector3 exposing (Vec3)
 import WebGL exposing (Mesh, Shader)
 
 
@@ -83,7 +82,7 @@ a function temperatureMap which transforms scalars to color vectors
 asHtml : Int -> Int -> CellGrid Float -> (Float -> Vec3) -> Html.Html msg
 asHtml width_ height_ cellGrid temperatureMap =
     let
-        (CellGrid ( nRows, nCols ) array) =
+        (CellGrid ( nRows, nCols ) _) =
             cellGrid
 
         dw =
@@ -105,13 +104,6 @@ asHtml width_ height_ cellGrid temperatureMap =
             (meshFromCellGrid ( dw, dh ) temperatureMap cellGrid)
             { perspective = Mat4.identity }
         ]
-
-
-
--- testMesh : Int -> Float -> Mesh Vertex
--- testMesh n ds =
---     testGrid ( n, n )
---         |> CellGrid.RenderWebGL.meshFromCellGrid ( ds, ds ) redMap
 
 
 meshWithColorizer : Colorizer -> ( Int, Int ) -> ( Float, Float ) -> Mesh Vertex
@@ -162,35 +154,6 @@ meshFromCellGridHelp ( dw, dh ) temperatureMap (CellGrid ( rows, cols ) array) =
         |> Tuple.second
 
 
-rectangleAtIndex : Colorizer -> ( Float, Float ) -> ( Int, Int ) -> List ( Vertex, Vertex, Vertex )
-rectangleAtIndex colorizer ( dw, dh ) ( i_, j_ ) =
-    let
-        i =
-            toFloat i_
-
-        j =
-            toFloat j_
-
-        x =
-            -1.0 + i * dw
-
-        y =
-            1.0 - j * dh
-
-        color_ =
-            colorizer ( i_, j_ )
-    in
-    [ ( Vertex x y 0 color_
-      , Vertex (x + dw) y 0 color_
-      , Vertex x (y - dh) 0 color_
-      )
-    , ( Vertex (x + dw) y 0 color_
-      , Vertex (x + dw) (y - dh) 0 color_
-      , Vertex x (y - dh) 0 color_
-      )
-    ]
-
-
 addRectangleAtIndex : Colorizer -> ( Float, Float ) -> ( Int, Int ) -> List ( Vertex, Vertex, Vertex ) -> List ( Vertex, Vertex, Vertex )
 addRectangleAtIndex colorizer ( dw, dh ) ( i_, j_ ) accum =
     let
@@ -222,39 +185,6 @@ addRectangleAtIndex colorizer ( dw, dh ) ( i_, j_ ) accum =
             )
     in
     v1 :: v2 :: accum
-
-
-rectangleFromElement :
-    (Float -> Vec3)
-    -> ( Float, Float )
-    -> ( ( Int, Int ), Float )
-    -> List ( Vertex, Vertex, Vertex )
-rectangleFromElement temperatureMap ( dw, dh ) ( ( i_, j_ ), t ) =
-    let
-        i =
-            toFloat i_
-
-        j =
-            toFloat j_
-
-        x =
-            -1.0 + i * dw
-
-        y =
-            1.0 - j * dh
-
-        color_ =
-            temperatureMap t
-    in
-    [ ( Vertex x y 0 color_
-      , Vertex (x + dw) y 0 color_
-      , Vertex x (y - dh) 0 color_
-      )
-    , ( Vertex (x + dw) y 0 color_
-      , Vertex (x + dw) (y - dh) 0 color_
-      , Vertex x (y - dh) 0 color_
-      )
-    ]
 
 
 addRectangleFromElement :

--- a/src/CellGrid/RenderWebGL.elm
+++ b/src/CellGrid/RenderWebGL.elm
@@ -36,7 +36,9 @@ import WebGL exposing (Mesh, Shader)
 {-| The type of vertices of triangles: define position and color.
 -}
 type alias Vertex =
-    { position : Vec3
+    { x : Float
+    , y : Float
+    , z : Float
     , color : Vec3
     }
 
@@ -167,13 +169,13 @@ rectangleAtIndex colorizer ( dw, dh ) ( i_, j_ ) =
         color_ =
             colorizer ( i_, j_ )
     in
-    [ ( Vertex (vec3 x y 0) color_
-      , Vertex (vec3 (x + dw) y 0) color_
-      , Vertex (vec3 x (y - dh) 0) color_
+    [ ( Vertex x y 0 color_
+      , Vertex (x + dw) y 0 color_
+      , Vertex x (y - dh) 0 color_
       )
-    , ( Vertex (vec3 (x + dw) y 0) color_
-      , Vertex (vec3 (x + dw) (y - dh) 0) color_
-      , Vertex (vec3 x (y - dh) 0) color_
+    , ( Vertex (x + dw) y 0 color_
+      , Vertex (x + dw) (y - dh) 0 color_
+      , Vertex x (y - dh) 0 color_
       )
     ]
 
@@ -200,13 +202,13 @@ rectangleFromElement temperatureMap ( dw, dh ) ( ( i_, j_ ), t ) =
         color_ =
             temperatureMap t
     in
-    [ ( Vertex (vec3 x y 0) color_
-      , Vertex (vec3 (x + dw) y 0) color_
-      , Vertex (vec3 x (y - dh) 0) color_
+    [ ( Vertex x y 0 color_
+      , Vertex (x + dw) y 0 color_
+      , Vertex x (y - dh) 0 color_
       )
-    , ( Vertex (vec3 (x + dw) y 0) color_
-      , Vertex (vec3 (x + dw) (y - dh) 0) color_
-      , Vertex (vec3 x (y - dh) 0) color_
+    , ( Vertex (x + dw) y 0 color_
+      , Vertex (x + dw) (y - dh) 0 color_
+      , Vertex x (y - dh) 0 color_
       )
     ]
 
@@ -215,13 +217,15 @@ vertexShader : Shader Vertex Uniforms { vcolor : Vec3 }
 vertexShader =
     [glsl|
 
-        attribute vec3 position;
+        attribute float x;
+        attribute float y;
+        attribute float z;
         attribute vec3 color;
         uniform mat4 perspective;
         varying vec3 vcolor;
 
         void main () {
-            gl_Position = perspective * vec4(position, 1.0);
+            gl_Position = perspective * vec4(x, y, z, 1.0);
             vcolor = color;
         }
 

--- a/tests/TestRenderWebGL.elm
+++ b/tests/TestRenderWebGL.elm
@@ -1,0 +1,63 @@
+module TestRenderWebGL exposing (suite)
+
+import CellGrid exposing (CellGrid, CellType(..), matrixIndices, setValue)
+import CellGrid.RenderWebGL
+import Color
+import Expect exposing (Expectation)
+import Fuzz exposing (Fuzzer, int, list, string)
+import Math.Vector3 as Vec3
+import Test exposing (..)
+import WebGL
+
+
+suite =
+    describe "render webgl"
+        [ describe "meshWithColorizer"
+            [ test "2x2 0x0" <|
+                \_ ->
+                    CellGrid.RenderWebGL.meshWithColorizerHelp (\_ -> Vec3.vec3 0 0 0) ( 2, 2 ) ( 0, 0 )
+                        |> Expect.equal
+                            [ ( { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 } )
+                            , ( { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 } )
+                            , ( { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 } )
+                            , ( { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 } )
+                            , ( { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 } )
+                            , ( { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 } )
+                            , ( { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 } )
+                            , ( { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 } )
+                            ]
+            , test "2x2 1x1" <|
+                \_ ->
+                    CellGrid.RenderWebGL.meshWithColorizerHelp (\_ -> Vec3.vec3 0 0 0) ( 2, 2 ) ( 1, 1 )
+                        |> Expect.equal
+                            [ ( { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = 0, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = 0, z = 0 } )
+                            , ( { color = Vec3.vec3 0 0 0, x = 0, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = 0, y = 0, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = 0, z = 0 } )
+                            , ( { color = Vec3.vec3 0 0 0, x = -1, y = 0, z = 0 }, { color = Vec3.vec3 0 0 0, x = 0, y = 0, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = -1, z = 0 } )
+                            , ( { color = Vec3.vec3 0 0 0, x = 0, y = 0, z = 0 }, { color = Vec3.vec3 0 0 0, x = 0, y = -1, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = -1, z = 0 } )
+                            , ( { color = Vec3.vec3 0 0 0, x = 0, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = 1, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = 0, y = 0, z = 0 } )
+                            , ( { color = Vec3.vec3 0 0 0, x = 1, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = 1, y = 0, z = 0 }, { color = Vec3.vec3 0 0 0, x = 0, y = 0, z = 0 } )
+                            , ( { color = Vec3.vec3 0 0 0, x = 0, y = 0, z = 0 }, { color = Vec3.vec3 0 0 0, x = 1, y = 0, z = 0 }, { color = Vec3.vec3 0 0 0, x = 0, y = -1, z = 0 } )
+                            , ( { color = Vec3.vec3 0 0 0, x = 1, y = 0, z = 0 }, { color = Vec3.vec3 0 0 0, x = 1, y = -1, z = 0 }, { color = Vec3.vec3 0 0 0, x = 0, y = -1, z = 0 } )
+                            ]
+            ]
+        , describe "meshFromCellGrid" <|
+            case CellGrid.fromList 2 2 [ 1.0, 2.0, 3.0, 4.0 ] of
+                Just cellGrid ->
+                    [ test "2x2 1x1" <|
+                        \_ ->
+                            CellGrid.RenderWebGL.meshFromCellGridHelp ( 1, 1 ) (\_ -> Vec3.vec3 0 0 0) cellGrid
+                                |> Expect.equal
+                                    [ ( { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = 0, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = 0, z = 0 } )
+                                    , ( { color = Vec3.vec3 0 0 0, x = 0, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = 0, y = 0, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = 0, z = 0 } )
+                                    , ( { color = Vec3.vec3 0 0 0, x = -1, y = 0, z = 0 }, { color = Vec3.vec3 0 0 0, x = 0, y = 0, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = -1, z = 0 } )
+                                    , ( { color = Vec3.vec3 0 0 0, x = 0, y = 0, z = 0 }, { color = Vec3.vec3 0 0 0, x = 0, y = -1, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = -1, z = 0 } )
+                                    , ( { color = Vec3.vec3 0 0 0, x = 0, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = 1, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = 0, y = 0, z = 0 } )
+                                    , ( { color = Vec3.vec3 0 0 0, x = 1, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = 1, y = 0, z = 0 }, { color = Vec3.vec3 0 0 0, x = 0, y = 0, z = 0 } )
+                                    , ( { color = Vec3.vec3 0 0 0, x = 0, y = 0, z = 0 }, { color = Vec3.vec3 0 0 0, x = 1, y = 0, z = 0 }, { color = Vec3.vec3 0 0 0, x = 0, y = -1, z = 0 } )
+                                    , ( { color = Vec3.vec3 0 0 0, x = 1, y = 0, z = 0 }, { color = Vec3.vec3 0 0 0, x = 1, y = -1, z = 0 }, { color = Vec3.vec3 0 0 0, x = 0, y = -1, z = 0 } )
+                                    ]
+                    ]
+
+                Nothing ->
+                    []
+        ]


### PR DESCRIPTION
Speed up webgl rendering

The main change is prevention of allocation of intermediate lists. Take eg
```elm
    List.range 0 (rows * cols - 1)
        |> List.map (matrixIndex ( rows, cols ))
        |> List.map rect
        |> List.concat
        |> WebGL.triangles
```
Here range creates a list, then both maps and the concat do too, so 4X the input is allocated.

The concat actually is worse than that. the `rect` function would allocate a 2-element list for every cell. By passing in the accumulator, those two elements can be cons'd onto the accumulator, thus preventing that allocation. 

I've also unpacked the `position : Vec3` field into three floats. There is still some discussion whether this is better. I saw a lot of time spent in allocating `Vec3`s, but it might be that the cost of sending the floats separately is not reported well in the chrome devtools. This needs more testing.