### PR TITLE
Make API resemble Array more

### DIFF
--- a/tests/MyTest.elm
+++ b/tests/MyTest.elm
@@ -1,7 +1,6 @@
 module MyTest exposing (suite)
 
 import CellGrid exposing (CellGrid, CellType(..), matrixIndices, setValue)
-import CellGrid.WebGL
 import Color
 import Expect exposing (Expectation)
 import Fuzz exposing (Fuzzer, int, list, string)
@@ -179,12 +178,12 @@ suite =
                             [ ( 0, 0 ), ( 0, 1 ), ( 0, 2 ), ( 1, 0 ), ( 1, 1 ), ( 1, 2 ) ]
                     in
                     Expect.equal indices1 indices2
-            , test "makeCellGrid" <|
+            , test "initialize" <|
                 \_ ->
                     let
                         cg =
                             Debug.log "CG" <|
-                                CellGrid.makeCellGrid ( 2, 3 ) (\( i, j ) -> toFloat (i + j))
+                                CellGrid.initialize ( 2, 3 ) (\( i, j ) -> toFloat (i + j))
 
                         temperature =
                             Debug.log "T" <|
@@ -193,6 +192,24 @@ suite =
                                 )
                     in
                     Expect.equal temperature 3.0
+            , test "initialize full" <|
+                \_ ->
+                    let
+                        cg =
+                            CellGrid.initialize ( 2, 3 ) (\( i, j ) -> toFloat (i + j))
+                    in
+                    cg
+                        |> Just
+                        |> Expect.equal (CellGrid.fromList 2 3 [ 0, 1, 2, 1, 2, 3 ])
+            , test "repeat" <|
+                \_ ->
+                    let
+                        cg =
+                            CellGrid.repeat ( 2, 3 ) 42
+                    in
+                    cg
+                        |> Just
+                        |> Expect.equal (CellGrid.fromList 2 3 (List.repeat (2 * 3) 42))
             , test "adjacent" <|
                 \_ ->
                     let


### PR DESCRIPTION
* rename `makeCellGrid` to `initialize` and optimize it
* add `repeat` 
* optimize `matrixIndices`
* shuffle the docs around a little to resemble `Array`.

This is breaking (requires a major release), so maybe rename
`initialize` back, but I like the matching of the `Array` api.

Maybe also `mapWithIndex` -> `indexedMap`, where the index is a `(row, column)` tuple.

And the unpacking of `Vertex.color` in RenderWebGL seems like a good idea.
The Vec3 instruction takes 30% of calculation time.I asked in the WebGL channel and there is a slight worry that the memory layout becomes less efficient, but don't think it's a big degradation while on the elm side it would be a big improvement.

I can put those changes in this PR if you want.