### PR TITLE
API revisions (not ready yet)

### DIFF
--- a/src/CellGrid.elm
+++ b/src/CellGrid.elm
@@ -298,7 +298,7 @@ matrixIndices (CellGrid ( nRows, nCols ) _) =
 cell grid of size `(row, column)` with the element at `(i, j)` set to the result of `f (i, j)`.
 
     CellGrid.initialize (2,2) Tuple.first
-        --> CellGrid.fromList [ 0, 0, 1, 1 ]
+        --> CellGrid.fromList 2 2 [ 0, 0, 1, 1 ]
 
     CellGrid.initalize ( 2, 3 ) (\( i, j ) -> toFloat (i + j))
         --> CellGrid.fromList 2 3 [ 0, 1, 2, 1, 2, 3 ]
@@ -329,6 +329,12 @@ initialize ( nRows, nCols ) temperatureMap =
     CellGrid ( nRows, nCols ) (go 0 0 Array.empty)
 
 
+{-| Fill a cell grid with a constant value
+
+    CellGrid.repeat (2,2) 42
+        --> CellGrid.fromList 2 2 [ 42, 42, 42, 42 ]
+
+-}
 repeat : ( Int, Int ) -> a -> CellGrid a
 repeat ( nRows, nCols ) value =
     let

--- a/src/CellGrid.elm
+++ b/src/CellGrid.elm
@@ -11,7 +11,7 @@ module CellGrid exposing
 
 {-| The CellGrid package provides a type for representing
 a rectangular grid of cells. CellGrids can be created,
-transformed, and rendered as either SVG or HTML.
+transformed, and rendered with either SVG or WebGL.
 
 
 ## Type

--- a/src/CellGrid/RenderWebGL.elm
+++ b/src/CellGrid/RenderWebGL.elm
@@ -142,7 +142,7 @@ meshFromCellGridHelp style (CellGrid ( rows, cols ) array) =
         folder : a -> ( Int, List ( Vertex, Vertex, Vertex ) ) -> ( Int, List ( Vertex, Vertex, Vertex ) )
         folder value ( index, accum ) =
             ( index - 1
-            , addRectangleFromElement style ( matrixIndex ( rows, cols ) index, value ) accum
+            , addRectangleFromElement style ( matrixIndex { rows = rows, columns = cols } index, value ) accum
             )
     in
     Array.foldr folder ( Array.length array - 1, [] ) array

--- a/src/CellGrid/RenderWebGL.elm
+++ b/src/CellGrid/RenderWebGL.elm
@@ -33,7 +33,7 @@ import Array
 import CellGrid exposing (CellGrid(..), matrixIndex)
 import Color exposing (Color)
 import Html
-import Html.Attributes exposing (height, style, width)
+import Html.Attributes
 import Math.Matrix4 as Mat4 exposing (Mat4)
 import Math.Vector3 exposing (Vec3)
 import WebGL exposing (Mesh, Shader)
@@ -65,11 +65,11 @@ type alias Colorizer =
 {-| Render a WebGL "drawing" to a given rectangle on the screen.
 -}
 meshToHtml : Int -> Int -> WebGL.Mesh Vertex -> Html.Html msg
-meshToHtml width_ height_ mesh =
+meshToHtml width height mesh =
     WebGL.toHtml
-        [ width width_
-        , height height_
-        , style "display" "block"
+        [ Html.Attributes.width width
+        , Html.Attributes.height height
+        , Html.Attributes.style "display" "block"
         ]
         [ WebGL.entity
             vertexShader
@@ -83,23 +83,23 @@ meshToHtml width_ height_ mesh =
 a function temperatureMap which transforms scalars to color vectors
 -}
 asHtml : Int -> Int -> CellGrid a -> (a -> Color) -> Html.Html msg
-asHtml width_ height_ cellGrid temperatureMap =
+asHtml width height cellGrid temperatureMap =
     let
         (CellGrid ( nRows, nCols ) _) =
             cellGrid
 
         dw =
-            toFloat width_
+            toFloat width
                 / toFloat (250 * nRows)
 
         dh =
-            toFloat height_
+            toFloat height
                 / toFloat (250 * nCols)
     in
     WebGL.toHtml
-        [ width width_
-        , height height_
-        , style "display" "block"
+        [ Html.Attributes.width width
+        , Html.Attributes.height height
+        , Html.Attributes.style "display" "block"
         ]
         [ WebGL.entity
             vertexShader

--- a/src/CellGrid/RenderWebGL.elm
+++ b/src/CellGrid/RenderWebGL.elm
@@ -32,7 +32,7 @@ Internal functions exposed for testing.
 -}
 
 import Array
-import CellGrid exposing (CellGrid(..), matrixIndex)
+import CellGrid exposing (CellGrid(..), Position, matrixIndex)
 import Color exposing (Color)
 import Html
 import Html.Attributes
@@ -151,22 +151,16 @@ meshFromCellGridHelp style (CellGrid { rows, columns } array) =
 
 addRectangleFromElement :
     CellStyle a
-    -> ( ( Int, Int ), a )
+    -> ( Position, a )
     -> List ( Vertex, Vertex, Vertex )
     -> List ( Vertex, Vertex, Vertex )
-addRectangleFromElement style ( ( i_, j_ ), t ) accum =
+addRectangleFromElement style ( position, t ) accum =
     let
-        i =
-            toFloat i_
-
-        j =
-            toFloat j_
-
         x =
-            -1.0 + i * style.cellWidth
+            -1.0 + toFloat position.row * style.cellWidth
 
         y =
-            1.0 - j * style.cellHeight
+            1.0 - toFloat position.column * style.cellHeight
 
         color =
             Color.toRgba (style.toColor t)

--- a/src/CellGrid/RenderWebGL.elm
+++ b/src/CellGrid/RenderWebGL.elm
@@ -46,14 +46,14 @@ The cells are stretched to use up all available space. For customized cell sizes
 
 -}
 asHtml : { width : Int, height : Int } -> (a -> Color) -> CellGrid a -> Html.Html msg
-asHtml ({ width, height } as canvas) toColor ((CellGrid ( nRows, nCols ) _) as cellGrid) =
+asHtml ({ width, height } as canvas) toColor ((CellGrid { rows, columns } _) as cellGrid) =
     let
         -- why 250?
         style : CellStyle a
         style =
             { toColor = toColor
-            , cellWidth = toFloat width / toFloat (250 * nRows)
-            , cellHeight = toFloat height / toFloat (250 * nCols)
+            , cellWidth = toFloat width / toFloat (250 * rows)
+            , cellHeight = toFloat height / toFloat (250 * columns)
             }
 
         mesh : Mesh Vertex
@@ -137,12 +137,12 @@ meshFromCellGrid style cellGrid =
 
 {-| -}
 meshFromCellGridHelp : CellStyle a -> CellGrid a -> List ( Vertex, Vertex, Vertex )
-meshFromCellGridHelp style (CellGrid ( rows, cols ) array) =
+meshFromCellGridHelp style (CellGrid { rows, columns } array) =
     let
         folder : a -> ( Int, List ( Vertex, Vertex, Vertex ) ) -> ( Int, List ( Vertex, Vertex, Vertex ) )
         folder value ( index, accum ) =
             ( index - 1
-            , addRectangleFromElement style ( matrixIndex { rows = rows, columns = cols } index, value ) accum
+            , addRectangleFromElement style ( matrixIndex { rows = rows, columns = columns } index, value ) accum
             )
     in
     Array.foldr folder ( Array.length array - 1, [] ) array

--- a/tests/TestRenderWebGL.elm
+++ b/tests/TestRenderWebGL.elm
@@ -1,6 +1,6 @@
 module TestRenderWebGL exposing (suite)
 
-import CellGrid exposing (CellGrid, CellType(..), matrixIndices, setValue)
+import CellGrid exposing (CellGrid, CellType(..), Dimensions, Position, matrixIndices)
 import CellGrid.RenderWebGL
 import Color exposing (Color)
 import Expect exposing (Expectation)
@@ -15,7 +15,7 @@ suite =
         [ describe "meshWithColorizer"
             [ test "2x2 0x0" <|
                 \_ ->
-                    meshWithColorizerNew (\_ -> Color.black) ( 2, 2 ) { width = 0, height = 0 }
+                    meshWithColorizerNew (Dimensions 2 2) { cellHeight = 0, cellWidth = 0, toColor = \_ -> Color.black }
                         |> Expect.equal
                             [ ( { r = 0, g = 0, b = 0, x = -1, y = 1, z = 0 }, { r = 0, g = 0, b = 0, x = -1, y = 1, z = 0 }, { r = 0, g = 0, b = 0, x = -1, y = 1, z = 0 } )
                             , ( { r = 0, g = 0, b = 0, x = -1, y = 1, z = 0 }, { r = 0, g = 0, b = 0, x = -1, y = 1, z = 0 }, { r = 0, g = 0, b = 0, x = -1, y = 1, z = 0 } )
@@ -28,7 +28,7 @@ suite =
                             ]
             , test "2x2 1x1" <|
                 \_ ->
-                    meshWithColorizerNew (\_ -> Color.black) ( 2, 2 ) { width = 1, height = 1 }
+                    meshWithColorizerNew (Dimensions 2 2) { cellHeight = 1, cellWidth = 1, toColor = \_ -> Color.black }
                         |> Expect.equal
                             [ ( { r = 0, g = 0, b = 0, x = -1, y = 1, z = 0 }, { r = 0, g = 0, b = 0, x = 0, y = 1, z = 0 }, { r = 0, g = 0, b = 0, x = -1, y = 0, z = 0 } )
                             , ( { r = 0, g = 0, b = 0, x = 0, y = 1, z = 0 }, { r = 0, g = 0, b = 0, x = 0, y = 0, z = 0 }, { r = 0, g = 0, b = 0, x = -1, y = 0, z = 0 } )
@@ -41,11 +41,11 @@ suite =
                             ]
             ]
         , describe "meshFromCellGrid" <|
-            case CellGrid.fromList 2 2 [ 1.0, 2.0, 3.0, 4.0 ] of
+            case CellGrid.fromList (Dimensions 2 2) [ 1.0, 2.0, 3.0, 4.0 ] of
                 Just cellGrid ->
                     [ test "2x2 1x1" <|
                         \_ ->
-                            CellGrid.RenderWebGL.meshFromCellGridHelp { width = 1, height = 1 } (\_ -> Color.black) cellGrid
+                            CellGrid.RenderWebGL.meshFromCellGridHelp { cellWidth = 1, cellHeight = 1, toColor = \_ -> Color.black } cellGrid
                                 |> Expect.equal
                                     [ ( { r = 0, g = 0, b = 0, x = -1, y = 1, z = 0 }, { r = 0, g = 0, b = 0, x = 0, y = 1, z = 0 }, { r = 0, g = 0, b = 0, x = -1, y = 0, z = 0 } )
                                     , ( { r = 0, g = 0, b = 0, x = 0, y = 1, z = 0 }, { r = 0, g = 0, b = 0, x = 0, y = 0, z = 0 }, { r = 0, g = 0, b = 0, x = -1, y = 0, z = 0 } )
@@ -64,13 +64,9 @@ suite =
 
 
 meshWithColorizerNew :
-    (( Int, Int ) -> Color)
-    -> ( Int, Int )
-    ->
-        { width : Float
-        , height : Float
-        }
+    Dimensions
+    -> CellGrid.RenderWebGL.CellStyle Position
     -> List ( CellGrid.RenderWebGL.Vertex, CellGrid.RenderWebGL.Vertex, CellGrid.RenderWebGL.Vertex )
-meshWithColorizerNew toColor size rectangle =
-    CellGrid.initialize size toColor
-        |> CellGrid.RenderWebGL.meshFromCellGridHelp rectangle identity
+meshWithColorizerNew size style =
+    CellGrid.initialize size (\i j -> style.toColor (Position i j))
+        |> CellGrid.RenderWebGL.meshFromCellGridHelp { cellWidth = style.cellWidth, cellHeight = style.cellHeight, toColor = identity }

--- a/tests/TestRenderWebGL.elm
+++ b/tests/TestRenderWebGL.elm
@@ -15,7 +15,7 @@ suite =
         [ describe "meshWithColorizer"
             [ test "2x2 0x0" <|
                 \_ ->
-                    CellGrid.RenderWebGL.meshWithColorizerHelp (\_ -> Color.black) ( 2, 2 ) { width = 0, height = 0 }
+                    meshWithColorizerNew (\_ -> Color.black) ( 2, 2 ) { width = 0, height = 0 }
                         |> Expect.equal
                             [ ( { r = 0, g = 0, b = 0, x = -1, y = 1, z = 0 }, { r = 0, g = 0, b = 0, x = -1, y = 1, z = 0 }, { r = 0, g = 0, b = 0, x = -1, y = 1, z = 0 } )
                             , ( { r = 0, g = 0, b = 0, x = -1, y = 1, z = 0 }, { r = 0, g = 0, b = 0, x = -1, y = 1, z = 0 }, { r = 0, g = 0, b = 0, x = -1, y = 1, z = 0 } )
@@ -28,7 +28,7 @@ suite =
                             ]
             , test "2x2 1x1" <|
                 \_ ->
-                    CellGrid.RenderWebGL.meshWithColorizerHelp (\_ -> Color.black) ( 2, 2 ) { width = 1, height = 1 }
+                    meshWithColorizerNew (\_ -> Color.black) ( 2, 2 ) { width = 1, height = 1 }
                         |> Expect.equal
                             [ ( { r = 0, g = 0, b = 0, x = -1, y = 1, z = 0 }, { r = 0, g = 0, b = 0, x = 0, y = 1, z = 0 }, { r = 0, g = 0, b = 0, x = -1, y = 0, z = 0 } )
                             , ( { r = 0, g = 0, b = 0, x = 0, y = 1, z = 0 }, { r = 0, g = 0, b = 0, x = 0, y = 0, z = 0 }, { r = 0, g = 0, b = 0, x = -1, y = 0, z = 0 } )
@@ -39,16 +39,6 @@ suite =
                             , ( { r = 0, g = 0, b = 0, x = 0, y = 0, z = 0 }, { r = 0, g = 0, b = 0, x = 1, y = 0, z = 0 }, { r = 0, g = 0, b = 0, x = 0, y = -1, z = 0 } )
                             , ( { r = 0, g = 0, b = 0, x = 1, y = 0, z = 0 }, { r = 0, g = 0, b = 0, x = 1, y = -1, z = 0 }, { r = 0, g = 0, b = 0, x = 0, y = -1, z = 0 } )
                             ]
-            , test "new implementation is equivalent" <|
-                \_ ->
-                    let
-                        old =
-                            CellGrid.RenderWebGL.meshWithColorizerHelp (\_ -> Color.black) ( 2, 2 ) { width = 1, height = 1 }
-
-                        new =
-                            meshWithColorizerNew (\_ -> Color.black) ( 2, 2 ) { width = 1, height = 1 }
-                    in
-                    new |> Expect.equal old
             ]
         , describe "meshFromCellGrid" <|
             case CellGrid.fromList 2 2 [ 1.0, 2.0, 3.0, 4.0 ] of

--- a/tests/TestRenderWebGL.elm
+++ b/tests/TestRenderWebGL.elm
@@ -2,12 +2,12 @@ module TestRenderWebGL exposing (suite)
 
 import CellGrid exposing (CellGrid, CellType(..), matrixIndices, setValue)
 import CellGrid.RenderWebGL
-import Color
+import Color exposing (Color)
 import Expect exposing (Expectation)
 import Fuzz exposing (Fuzzer, int, list, string)
 import Math.Vector3 as Vec3
 import Test exposing (..)
-import WebGL
+import WebGL exposing (Mesh)
 
 
 suite =
@@ -15,49 +15,72 @@ suite =
         [ describe "meshWithColorizer"
             [ test "2x2 0x0" <|
                 \_ ->
-                    CellGrid.RenderWebGL.meshWithColorizerHelp (\_ -> Vec3.vec3 0 0 0) ( 2, 2 ) ( 0, 0 )
+                    CellGrid.RenderWebGL.meshWithColorizerHelp (\_ -> Color.black) ( 2, 2 ) { width = 0, height = 0 }
                         |> Expect.equal
-                            [ ( { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 } )
-                            , ( { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 } )
-                            , ( { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 } )
-                            , ( { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 } )
-                            , ( { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 } )
-                            , ( { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 } )
-                            , ( { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 } )
-                            , ( { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 } )
+                            [ ( { r = 0, g = 0, b = 0, x = -1, y = 1, z = 0 }, { r = 0, g = 0, b = 0, x = -1, y = 1, z = 0 }, { r = 0, g = 0, b = 0, x = -1, y = 1, z = 0 } )
+                            , ( { r = 0, g = 0, b = 0, x = -1, y = 1, z = 0 }, { r = 0, g = 0, b = 0, x = -1, y = 1, z = 0 }, { r = 0, g = 0, b = 0, x = -1, y = 1, z = 0 } )
+                            , ( { r = 0, g = 0, b = 0, x = -1, y = 1, z = 0 }, { r = 0, g = 0, b = 0, x = -1, y = 1, z = 0 }, { r = 0, g = 0, b = 0, x = -1, y = 1, z = 0 } )
+                            , ( { r = 0, g = 0, b = 0, x = -1, y = 1, z = 0 }, { r = 0, g = 0, b = 0, x = -1, y = 1, z = 0 }, { r = 0, g = 0, b = 0, x = -1, y = 1, z = 0 } )
+                            , ( { r = 0, g = 0, b = 0, x = -1, y = 1, z = 0 }, { r = 0, g = 0, b = 0, x = -1, y = 1, z = 0 }, { r = 0, g = 0, b = 0, x = -1, y = 1, z = 0 } )
+                            , ( { r = 0, g = 0, b = 0, x = -1, y = 1, z = 0 }, { r = 0, g = 0, b = 0, x = -1, y = 1, z = 0 }, { r = 0, g = 0, b = 0, x = -1, y = 1, z = 0 } )
+                            , ( { r = 0, g = 0, b = 0, x = -1, y = 1, z = 0 }, { r = 0, g = 0, b = 0, x = -1, y = 1, z = 0 }, { r = 0, g = 0, b = 0, x = -1, y = 1, z = 0 } )
+                            , ( { r = 0, g = 0, b = 0, x = -1, y = 1, z = 0 }, { r = 0, g = 0, b = 0, x = -1, y = 1, z = 0 }, { r = 0, g = 0, b = 0, x = -1, y = 1, z = 0 } )
                             ]
             , test "2x2 1x1" <|
                 \_ ->
-                    CellGrid.RenderWebGL.meshWithColorizerHelp (\_ -> Vec3.vec3 0 0 0) ( 2, 2 ) ( 1, 1 )
+                    CellGrid.RenderWebGL.meshWithColorizerHelp (\_ -> Color.black) ( 2, 2 ) { width = 1, height = 1 }
                         |> Expect.equal
-                            [ ( { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = 0, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = 0, z = 0 } )
-                            , ( { color = Vec3.vec3 0 0 0, x = 0, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = 0, y = 0, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = 0, z = 0 } )
-                            , ( { color = Vec3.vec3 0 0 0, x = -1, y = 0, z = 0 }, { color = Vec3.vec3 0 0 0, x = 0, y = 0, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = -1, z = 0 } )
-                            , ( { color = Vec3.vec3 0 0 0, x = 0, y = 0, z = 0 }, { color = Vec3.vec3 0 0 0, x = 0, y = -1, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = -1, z = 0 } )
-                            , ( { color = Vec3.vec3 0 0 0, x = 0, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = 1, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = 0, y = 0, z = 0 } )
-                            , ( { color = Vec3.vec3 0 0 0, x = 1, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = 1, y = 0, z = 0 }, { color = Vec3.vec3 0 0 0, x = 0, y = 0, z = 0 } )
-                            , ( { color = Vec3.vec3 0 0 0, x = 0, y = 0, z = 0 }, { color = Vec3.vec3 0 0 0, x = 1, y = 0, z = 0 }, { color = Vec3.vec3 0 0 0, x = 0, y = -1, z = 0 } )
-                            , ( { color = Vec3.vec3 0 0 0, x = 1, y = 0, z = 0 }, { color = Vec3.vec3 0 0 0, x = 1, y = -1, z = 0 }, { color = Vec3.vec3 0 0 0, x = 0, y = -1, z = 0 } )
+                            [ ( { r = 0, g = 0, b = 0, x = -1, y = 1, z = 0 }, { r = 0, g = 0, b = 0, x = 0, y = 1, z = 0 }, { r = 0, g = 0, b = 0, x = -1, y = 0, z = 0 } )
+                            , ( { r = 0, g = 0, b = 0, x = 0, y = 1, z = 0 }, { r = 0, g = 0, b = 0, x = 0, y = 0, z = 0 }, { r = 0, g = 0, b = 0, x = -1, y = 0, z = 0 } )
+                            , ( { r = 0, g = 0, b = 0, x = -1, y = 0, z = 0 }, { r = 0, g = 0, b = 0, x = 0, y = 0, z = 0 }, { r = 0, g = 0, b = 0, x = -1, y = -1, z = 0 } )
+                            , ( { r = 0, g = 0, b = 0, x = 0, y = 0, z = 0 }, { r = 0, g = 0, b = 0, x = 0, y = -1, z = 0 }, { r = 0, g = 0, b = 0, x = -1, y = -1, z = 0 } )
+                            , ( { r = 0, g = 0, b = 0, x = 0, y = 1, z = 0 }, { r = 0, g = 0, b = 0, x = 1, y = 1, z = 0 }, { r = 0, g = 0, b = 0, x = 0, y = 0, z = 0 } )
+                            , ( { r = 0, g = 0, b = 0, x = 1, y = 1, z = 0 }, { r = 0, g = 0, b = 0, x = 1, y = 0, z = 0 }, { r = 0, g = 0, b = 0, x = 0, y = 0, z = 0 } )
+                            , ( { r = 0, g = 0, b = 0, x = 0, y = 0, z = 0 }, { r = 0, g = 0, b = 0, x = 1, y = 0, z = 0 }, { r = 0, g = 0, b = 0, x = 0, y = -1, z = 0 } )
+                            , ( { r = 0, g = 0, b = 0, x = 1, y = 0, z = 0 }, { r = 0, g = 0, b = 0, x = 1, y = -1, z = 0 }, { r = 0, g = 0, b = 0, x = 0, y = -1, z = 0 } )
                             ]
+            , test "new implementation is equivalent" <|
+                \_ ->
+                    let
+                        old =
+                            CellGrid.RenderWebGL.meshWithColorizerHelp (\_ -> Color.black) ( 2, 2 ) { width = 1, height = 1 }
+
+                        new =
+                            meshWithColorizerNew (\_ -> Color.black) ( 2, 2 ) { width = 1, height = 1 }
+                    in
+                    new |> Expect.equal old
             ]
         , describe "meshFromCellGrid" <|
             case CellGrid.fromList 2 2 [ 1.0, 2.0, 3.0, 4.0 ] of
                 Just cellGrid ->
                     [ test "2x2 1x1" <|
                         \_ ->
-                            CellGrid.RenderWebGL.meshFromCellGridHelp ( 1, 1 ) (\_ -> Vec3.vec3 0 0 0) cellGrid
+                            CellGrid.RenderWebGL.meshFromCellGridHelp { width = 1, height = 1 } (\_ -> Color.black) cellGrid
                                 |> Expect.equal
-                                    [ ( { color = Vec3.vec3 0 0 0, x = -1, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = 0, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = 0, z = 0 } )
-                                    , ( { color = Vec3.vec3 0 0 0, x = 0, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = 0, y = 0, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = 0, z = 0 } )
-                                    , ( { color = Vec3.vec3 0 0 0, x = -1, y = 0, z = 0 }, { color = Vec3.vec3 0 0 0, x = 0, y = 0, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = -1, z = 0 } )
-                                    , ( { color = Vec3.vec3 0 0 0, x = 0, y = 0, z = 0 }, { color = Vec3.vec3 0 0 0, x = 0, y = -1, z = 0 }, { color = Vec3.vec3 0 0 0, x = -1, y = -1, z = 0 } )
-                                    , ( { color = Vec3.vec3 0 0 0, x = 0, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = 1, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = 0, y = 0, z = 0 } )
-                                    , ( { color = Vec3.vec3 0 0 0, x = 1, y = 1, z = 0 }, { color = Vec3.vec3 0 0 0, x = 1, y = 0, z = 0 }, { color = Vec3.vec3 0 0 0, x = 0, y = 0, z = 0 } )
-                                    , ( { color = Vec3.vec3 0 0 0, x = 0, y = 0, z = 0 }, { color = Vec3.vec3 0 0 0, x = 1, y = 0, z = 0 }, { color = Vec3.vec3 0 0 0, x = 0, y = -1, z = 0 } )
-                                    , ( { color = Vec3.vec3 0 0 0, x = 1, y = 0, z = 0 }, { color = Vec3.vec3 0 0 0, x = 1, y = -1, z = 0 }, { color = Vec3.vec3 0 0 0, x = 0, y = -1, z = 0 } )
+                                    [ ( { r = 0, g = 0, b = 0, x = -1, y = 1, z = 0 }, { r = 0, g = 0, b = 0, x = 0, y = 1, z = 0 }, { r = 0, g = 0, b = 0, x = -1, y = 0, z = 0 } )
+                                    , ( { r = 0, g = 0, b = 0, x = 0, y = 1, z = 0 }, { r = 0, g = 0, b = 0, x = 0, y = 0, z = 0 }, { r = 0, g = 0, b = 0, x = -1, y = 0, z = 0 } )
+                                    , ( { r = 0, g = 0, b = 0, x = -1, y = 0, z = 0 }, { r = 0, g = 0, b = 0, x = 0, y = 0, z = 0 }, { r = 0, g = 0, b = 0, x = -1, y = -1, z = 0 } )
+                                    , ( { r = 0, g = 0, b = 0, x = 0, y = 0, z = 0 }, { r = 0, g = 0, b = 0, x = 0, y = -1, z = 0 }, { r = 0, g = 0, b = 0, x = -1, y = -1, z = 0 } )
+                                    , ( { r = 0, g = 0, b = 0, x = 0, y = 1, z = 0 }, { r = 0, g = 0, b = 0, x = 1, y = 1, z = 0 }, { r = 0, g = 0, b = 0, x = 0, y = 0, z = 0 } )
+                                    , ( { r = 0, g = 0, b = 0, x = 1, y = 1, z = 0 }, { r = 0, g = 0, b = 0, x = 1, y = 0, z = 0 }, { r = 0, g = 0, b = 0, x = 0, y = 0, z = 0 } )
+                                    , ( { r = 0, g = 0, b = 0, x = 0, y = 0, z = 0 }, { r = 0, g = 0, b = 0, x = 1, y = 0, z = 0 }, { r = 0, g = 0, b = 0, x = 0, y = -1, z = 0 } )
+                                    , ( { r = 0, g = 0, b = 0, x = 1, y = 0, z = 0 }, { r = 0, g = 0, b = 0, x = 1, y = -1, z = 0 }, { r = 0, g = 0, b = 0, x = 0, y = -1, z = 0 } )
                                     ]
                     ]
 
                 Nothing ->
                     []
         ]
+
+
+meshWithColorizerNew :
+    (( Int, Int ) -> Color)
+    -> ( Int, Int )
+    ->
+        { width : Float
+        , height : Float
+        }
+    -> List ( CellGrid.RenderWebGL.Vertex, CellGrid.RenderWebGL.Vertex, CellGrid.RenderWebGL.Vertex )
+meshWithColorizerNew toColor size rectangle =
+    CellGrid.initialize size toColor
+        |> CellGrid.RenderWebGL.meshFromCellGridHelp rectangle identity


### PR DESCRIPTION
I took some initiative and made some big api changes, leading to something that I think looks pretty nice. The main visible change is the distinction between dimensions and positions, formerly both represented as `(Int, Int)`. 

```elm
type alias Dimensions = { rows : Int , columns : Int }

type alias Position = { row : Int , column : Int }

classifyCell : Position -> CellGrid a -> CellType
set : Position -> a -> CellGrid a -> CellGrid a
-- etc.
```

Which would be used like 

```elm
import Array

CellGrid.initialize (Dimensions 2 2) (\i j -> i)
    --> CellGrid (Dimensions 2 2) (Array.fromList [ 0, 0, 1, 1 ])

CellGrid.initialize (Dimensions 2 3) (\i j -> toFloat (i + j))
    --> CellGrid (Dimensions 2 3) (Array.fromList [ 0, 1, 2, 1, 2, 3 ])
```

and 

```elm
cg : CellGrid Int
cg = CellGrid.repeat (Dimensions 2 2) 42

CellGrid.set (Position 1 1) 84 cg
    --> CellGrid (Dimensions 2 2) (Array.fromList [42,42,42,84])
```

`Position i j` is longer that just `(i, j)`, but I think the explicitness is worth it. 

I've also added examples verified with elm-verify-examples for most functions. 

I still want to do a pass over the documentation and need to clean up some things. Then make the tests work again. 