### PR TITLE
add image rendering with `CellGrid.Image`

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -7,17 +7,21 @@
     "exposed-modules": [
         "CellGrid",
         "CellGrid.Render",
-        "CellGrid.RenderWebGL"
+        "CellGrid.RenderWebGL",
+        "CellGrid.Image"
     ],
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
         "avh4/elm-color": "1.0.0 <= v < 2.0.0",
+        "danfishgold/base64-bytes": "1.0.2 <= v < 2.0.0",
+        "elm/bytes": "1.0.8 <= v < 2.0.0",
         "elm/core": "1.0.2 <= v < 2.0.0",
         "elm/html": "1.0.0 <= v < 2.0.0",
         "elm/random": "1.0.0 <= v < 2.0.0",
         "elm/svg": "1.0.1 <= v < 2.0.0",
         "elm-community/typed-svg": "5.0.1 <= v < 6.0.0",
         "elm-explorations/webgl": "1.1.0 <= v < 2.0.0",
+        "justgook/elm-image": "2.0.1 <= v < 3.0.0",
         "mpizenberg/elm-pointer-events": "4.0.1 <= v < 5.0.0"
     },
     "test-dependencies": {

--- a/examples/HeatMap/README.md
+++ b/examples/HeatMap/README.md
@@ -7,36 +7,18 @@ a WebGL images from some mathematial function.
 
 Construct a 700x700 pixel image using 
 
+```elm
+colorAtMatrixIndex : Dimensions -> Position -> Color
 ```
-   colorAtMatrixIndex : ( Int, Int ) -> ( Int, Int ) -> Vec3
-```
-
-Here 
-
-```
-   colorAtMatrixIndex ( row, col ) : ( Int, Int ) -> Vec3
-```
-
-is a function that assigns an RGB value, represented as a 3-vector : Vec3,
-to position (i, j).  Such a function is fed to 
- `RenderWegGL.meshWithColorizer` to create a `Mesh Vertex` values.
- These can be rendered using `CellGrid.RenderWebGL.meshToHtml`.
-
-
 
 ## Image2
 
 Construct a 700x700 pixel image using 
 
-```
-   colorAtMatrixIndex : ( Int, Int ) -> ( Int, Int ) -> Vec3
-```
-
-Here 
-
-```
-   colorAtMatrixIndex ( row, col ) : ( Int, Int ) -> Vec3
+```elm
+colorAtMatrixIndex : Dimensions -> Position -> Color
 ```
 
-is a function that assigns an RGB value, represented as a 3-vector : Vec3,
-to postion (i, j).
+## Image3 
+
+Same coloring function as Image1, but uses `CellGrid.Image` to render it.

--- a/examples/HeatMap/elm.json
+++ b/examples/HeatMap/elm.json
@@ -8,19 +8,23 @@
     "dependencies": {
         "direct": {
             "avh4/elm-color": "1.0.0",
+            "danfishgold/base64-bytes": "1.0.2",
             "elm/browser": "1.0.1",
+            "elm/bytes": "1.0.8",
             "elm/core": "1.0.2",
             "elm/html": "1.0.0",
             "elm/json": "1.1.3",
             "elm-explorations/webgl": "1.1.0",
+            "justgook/elm-image": "2.0.1",
             "mpizenberg/elm-pointer-events": "4.0.1"
         },
         "indirect": {
-            "elm/bytes": "1.0.8",
             "elm/file": "1.0.5",
             "elm/time": "1.0.0",
             "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.2",
+            "elm-community/list-extra": "8.2.2",
+            "folkertdev/elm-flate": "2.0.2"
         }
     },
     "test-dependencies": {

--- a/examples/HeatMap/src/Image3.elm
+++ b/examples/HeatMap/src/Image3.elm
@@ -1,15 +1,29 @@
-module Image1 exposing (main)
+module Image3 exposing (main)
+
+{-| Render a cellgrid as a bmp image and display it using HTML
+-}
 
 import CellGrid exposing (CellGrid(..), Dimensions, Position)
-import CellGrid.RenderWebGL exposing (CellStyle, Vertex, meshFromCellGrid)
+import CellGrid.Image
 import Color exposing (Color)
 import Html exposing (Html)
-import WebGL exposing (Mesh)
+import Html.Attributes
+
+
+size : Int
+size =
+    100
 
 
 main : Html msg
 main =
-    CellGrid.RenderWebGL.meshToHtml { width = 1200, height = 1200 } mesh
+    Html.img
+        [ Html.Attributes.src (CellGrid.Image.asBmpUri grid)
+        , Html.Attributes.width 600
+        , Html.Attributes.height 600
+        , Html.Attributes.style "image-rendering" "pixelated"
+        ]
+        []
 
 
 grid : CellGrid Color
@@ -17,26 +31,13 @@ grid =
     let
         dimensions : Dimensions
         dimensions =
-            Dimensions 100 100
+            Dimensions size size
 
         initializer : Int -> Int -> Color
         initializer i j =
             colorAtMatrixIndex dimensions (Position i j)
     in
     CellGrid.initialize dimensions initializer
-
-
-cellStyle : CellStyle Color
-cellStyle =
-    { toColor = identity
-    , cellWidth = 0.01
-    , cellHeight = 0.01
-    }
-
-
-mesh : Mesh Vertex
-mesh =
-    meshFromCellGrid cellStyle grid
 
 
 colorAtMatrixIndex : Dimensions -> Position -> Color
@@ -58,3 +59,4 @@ colorAtMatrixIndex dimensions position =
             sin (4.1 * pi * jRatio)
     in
     Color.rgb (0.5 + 0.3 * s1) 0.0 (0.5 + 0.5 * s2)
+

--- a/src/CellGrid.elm
+++ b/src/CellGrid.elm
@@ -486,26 +486,17 @@ cell grid of size `(Dimensions row column)` with the element at `(Position i j)`
 initialize : Dimensions -> (Int -> Int -> a) -> CellGrid a
 initialize dimensions temperatureMap =
     let
-        maxRow =
-            dimensions.rows - 1
+        helper index =
+            let
+                row =
+                    index // dimensions.columns
 
-        maxColumn =
-            dimensions.columns - 1
-
-        go row column accum =
-            if row > maxRow then
-                -- row is outside of range: stop
-                accum
-
-            else if column == maxColumn then
-                -- last column of the row: increment row, reset column
-                go (row + 1) 0 (Array.push (temperatureMap row column) accum)
-
-            else
-                -- somewhere in the interior: increment column
-                go row (column + 1) (Array.push (temperatureMap row column) accum)
+                column =
+                    remainderBy dimensions.columns index
+            in
+            temperatureMap row column
     in
-    CellGrid dimensions (go 0 0 Array.empty)
+    CellGrid dimensions (Array.initialize (dimensions.rows * dimensions.columns) helper)
 
 
 {-| Fill a cell grid with a constant value

--- a/src/CellGrid/Image.elm
+++ b/src/CellGrid/Image.elm
@@ -1,0 +1,114 @@
+module CellGrid.Image exposing
+    ( asBmpUri, asPngUri
+    , asBmpBytes, asPngBytes
+    )
+
+{-| Render a cellgrid as a bmp or png image
+
+
+## Data URI
+
+[Data URIs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs) using the base64 encoding are a way to create an image from binary data in the browser.
+This makes it possible to generate an image in pure elm and display it using HTML.
+
+    import CellGrid exposing (CellGrid, Dimensions)
+    import CellGrid.Image
+    import Color exposing (Color)
+    import Html
+    import Html.Attributes exposing (height, src, style, width)
+
+    grid : CellGrid Color
+    grid =
+        CellGrid.repeat (Dimensions 2 2) Color.red
+
+    main : Html msg
+    main =
+        Html.img
+            [ src (CellGrid.Image.asBmpUri grid)
+            , width 300
+            , height 300
+            , style "image-rendering" "pixelated"
+            ]
+
+@docs asBmpUri, asPngUri
+
+
+## Bytes
+
+@docs asBmpBytes, asPngBytes
+
+-}
+
+import Base64
+import Bytes exposing (Bytes)
+import CellGrid exposing (CellGrid)
+import Color exposing (Color)
+import Image exposing (Image)
+import Image.Color
+
+
+{-| Convert to a `Image` from `justgook/elm-image`.
+-}
+toImage : CellGrid Color -> Image
+toImage grid =
+    Image.Color.fromList2d (CellGrid.toLists grid)
+
+
+{-| Encode a `CellGrid` as a bmp image.
+-}
+asBmpBytes : CellGrid Color -> Bytes
+asBmpBytes =
+    Image.encodeBmp << toImage
+
+
+{-| Encode a `CellGrid` as a png image.
+-}
+asPngBytes : CellGrid Color -> Bytes
+asPngBytes =
+    Image.encodePng << toImage
+
+
+{-| Encode a `CellGrid` as a bmp URI.
+
+    import CellGrid exposing (CellGrid, Dimensions)
+    import Color exposing (Color)
+
+    grid : CellGrid Color
+    grid =
+        CellGrid.repeat (Dimensions 2 2) (Color.red)
+
+    asBmpUri grid
+        --> "data:image/bmp;base64,Qk2KAAAAAAAAAHoAAABsAAAAAgAAAAIAAAABACAAAwAAABAAAAATCwAAEwsAAAAAAAAAAAAAAAAA/wAA/wAA/wAA/wAAAFdpbiAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD/AADM/wAAzP8AAMz/AADM"
+
+-}
+asBmpUri : CellGrid Color -> String
+asBmpUri grid =
+    let
+        encoded =
+            Base64.fromBytes (asBmpBytes grid)
+                |> Maybe.withDefault ""
+    in
+    "data:image/bmp;base64," ++ encoded
+
+
+{-| Encode a `CellGrid` as a png URI.
+
+    import CellGrid exposing (CellGrid, Dimensions)
+    import Color exposing (Color)
+
+    grid : CellGrid Color
+    grid =
+        CellGrid.repeat (Dimensions 2 2) (Color.red)
+
+    asPngUri grid
+        --> "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAGklEQVR4nD3GsQEAAADBsPr/NT9hkikyhHkKJwYDmXkNWg4AAAAASUVORK5CYII="
+
+-}
+asPngUri : CellGrid Color -> String
+asPngUri grid =
+    let
+        encoded =
+            Base64.fromBytes (asPngBytes grid)
+                |> Maybe.withDefault ""
+    in
+    "data:image/png;base64," ++ encoded

--- a/src/CellGrid/Render.elm
+++ b/src/CellGrid/Render.elm
@@ -16,19 +16,8 @@ import CellGrid exposing (CellGrid(..), Position)
 import Color exposing (Color)
 import Html exposing (Html)
 import Html.Events.Extra.Mouse as Mouse
--- import Svg exposing (Svg)
--- import Svg.Attributes
-
-
-
-{-
-   import Svg exposing (g, rect, svg)
-   import Svg.Attributes exposing (fill, stroke, viewBox)
-   import TypedSvg.Attributes.InPx exposing (height, strokeWidth, width, x, y)
-   import TypedSvg.Core exposing (Svg)
-   import TypedSvg.Types exposing (Fill(..))
-
--}
+import Svg exposing (Svg)
+import Svg.Attributes
 
 
 {-| Customize how a cell is rendered.

--- a/src/CellGrid/RenderWebGL.elm
+++ b/src/CellGrid/RenderWebGL.elm
@@ -48,12 +48,15 @@ The cells are stretched to use up all available space. For customized cell sizes
 asHtml : { width : Int, height : Int } -> (a -> Color) -> CellGrid a -> Html.Html msg
 asHtml ({ width, height } as canvas) toColor ((CellGrid { rows, columns } _) as cellGrid) =
     let
-        -- why 250?
         style : CellStyle a
         style =
             { toColor = toColor
-            , cellWidth = toFloat width / toFloat (250 * columns)
-            , cellHeight = toFloat height / toFloat (250 * rows)
+            , cellWidth =
+                0.1
+                    / (toFloat width / toFloat columns)
+            , cellHeight =
+                0.1
+                    / (toFloat height / toFloat rows)
             }
 
         mesh : Mesh Vertex

--- a/src/CellGrid/RenderWebGL.elm
+++ b/src/CellGrid/RenderWebGL.elm
@@ -7,8 +7,11 @@ module CellGrid.RenderWebGL exposing
     , meshFromCellGridHelp
     )
 
-{-| Render a `CellGrid` using WebGL. WebGL is typically faster for a large (1000+) cell grids.
+{-| Render a `CellGrid` using WebGL.
 See also the [examples](https://github.com/jxxcarlson/elm-cell-grid/tree/master/examples).
+
+> **Note:** WebGL can only handle grids of about `100x100`.
+> Drawing more cells exceeds the vertex limit, resulting in a partially blank image. `CellGrid.Image` can handle larger grids with ease.
 
 
 ## Rendering functions

--- a/tests/TestRenderWebGL.elm
+++ b/tests/TestRenderWebGL.elm
@@ -5,7 +5,6 @@ import CellGrid.RenderWebGL
 import Color exposing (Color)
 import Expect exposing (Expectation)
 import Fuzz exposing (Fuzzer, int, list, string)
-import Math.Vector3 as Vec3
 import Test exposing (..)
 import WebGL exposing (Mesh)
 

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -1,0 +1,4 @@
+{
+  "root": "../src",
+  "tests": [ "CellGrid", "CellGrid.Image"]
+}


### PR DESCRIPTION
This PR adds image rendering functionality.

For the `examples/HeatMap/src/Image1.elm` file, rendering as an image is 5 times faster.